### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,7 +12,7 @@ DS1624	KEYWORD1
 # Methods and Functions (KEYWORD2)
 ###########################################
 
-GetTemperature KEYWORD2
-StopConversion KEYWORD2
-StartConversion KEYWORD2
+GetTemperature	KEYWORD2
+StopConversion	KEYWORD2
+StartConversion	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords