### PR TITLE
Fixed mask for lsb a2, a1, and a0.

### DIFF
--- a/src/DS1624.cpp
+++ b/src/DS1624.cpp
@@ -48,7 +48,7 @@ DS1624::DS1624(uint8_t addressByPins)
   _temperatureValueValid = true;
   
   // Base address least significant bits will be a2, a1, a0 respectively 
-  _address = 0x48 + (addressByPins & 0xf8);
+  _address = 0x48 + (addressByPins & 0x07);
 }
 
 void DS1624::Init()


### PR DESCRIPTION
Hello. This fix was required for addressing to work with multiple DS1624's on same bus.  Thanks for considering.  